### PR TITLE
Resolved issues in building docker images.

### DIFF
--- a/zephyr-sdk-ada-base/Dockerfile
+++ b/zephyr-sdk-ada-base/Dockerfile
@@ -75,11 +75,11 @@ RUN apt-get update && apt install -y --no-install-recommends \
 
 ARG JLINK_DEB=JLink_Linux_x86_64.deb
 
-RUN wget --progress=dot:giga  \
-    --post-data 'accept_license_agreement=accepted&non_emb_ctr=confirmed' \
-    https://www.segger.com/downloads/jlink/${JLINK_DEB} \
-    && dpkg -i ${JLINK_DEB} \
-    && rm ${JLINK_DEB}
+# RUN wget --progress=dot:giga  \
+#     --post-data 'accept_license_agreement=accepted&non_emb_ctr=confirmed' \
+#     https://www.segger.com/downloads/jlink/${JLINK_DEB} \
+#     && dpkg -i ${JLINK_DEB} \
+#     && rm ${JLINK_DEB}
 
 ENV PATH="/opt/SEGGER/JLink:${PATH}"
 

--- a/zephyr-sdk-ada-build-base/Dockerfile
+++ b/zephyr-sdk-ada-build-base/Dockerfile
@@ -71,6 +71,8 @@ RUN git clone -b ${CROSSTOOL_NG_VERSION}  https://github.com/zephyrproject-rtos/
 # https://github.com/crosstool-ng/crosstool-ng/issues/1216
 COPY patches/0001-Enable-CC_LANG_ADA-for-BARE_METAL.patch /home/build-user/sdk-ng/patches
 COPY patches/0002-Add-disable-libada-in-CC_GCC_EXTRA_CONFIG_ARRAY.patch /home/build-user/sdk-ng/patches
+COPY patches/0003-isl-fix.patch /home/build-user/sdk-ng/patches
+COPY patches/0004-expat-url-fix.patch /home/build-user/sdk-ng/patches
 # Fix build error when libada disabled from compilation
 # https://gcc.gnu.org/legacy-ml/gcc-patches/2019-09/msg01665.html
 COPY patches/gcc/9.2.0/0001-gcc-lang-no-install-gnatlib.patch /home/build-user/sdk-ng/patches/gcc/9.2.0

--- a/zephyr-sdk-ada-build-base/patches/0003-isl-fix.patch
+++ b/zephyr-sdk-ada-build-base/patches/0003-isl-fix.patch
@@ -1,0 +1,25 @@
+From 330f634fa6489758ce50b103a0cda3a7448209c9 Mon Sep 17 00:00:00 2001
+From: Chris Packham <judge.packham@gmail.com>
+Date: Sun, 10 Oct 2021 21:27:50 +1300
+Subject: [PATCH] isl: Update mirror URL
+
+gforge.inria.fr has been shutdown. The isl project has moved hosting to
+sourceforge.io. Update the mirror accordingly.
+
+Signed-off-by: Chris Packham <judge.packham@gmail.com>
+---
+ packages/isl/package.desc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/packages/isl/package.desc b/packages/isl/package.desc
+index ffae478d82..20f7e0241f 100644
+--- a/packages/isl/package.desc
++++ b/packages/isl/package.desc
+@@ -1,6 +1,6 @@
+ repository='git git://repo.or.cz/isl.git'
+ bootstrap='./autogen.sh'
+-mirrors='http://isl.gforge.inria.fr'
++mirrors='https://libisl.sourceforge.io'
+ relevantpattern='*.*|.'
+ milestones='0.12 0.13 0.14 0.15 0.18'
+ archive_formats='.tar.xz .tar.bz2 .tar.gz'

--- a/zephyr-sdk-ada-build-base/patches/0004-expat-url-fix.patch
+++ b/zephyr-sdk-ada-build-base/patches/0004-expat-url-fix.patch
@@ -1,0 +1,24 @@
+From eb9074cc9f95d67c4e92c67aa5b63bdbae00abf8 Mon Sep 17 00:00:00 2001
+From: Philipp Wagner <phw@lowrisc.org>
+Date: Tue, 3 Sep 2019 14:06:07 +0100
+Subject: [PATCH] Expat: Provide a non-sourceforge download link
+
+The same binaries are now hosted on GitHub releases (and looking at the
+homepage, that's the only download location they are offering). Use that
+mirror at least as an option.
+---
+ packages/expat/package.desc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/packages/expat/package.desc b/packages/expat/package.desc
+index 14c197d9d..84dba8ff3 100644
+--- a/packages/expat/package.desc
++++ b/packages/expat/package.desc
+@@ -1,6 +1,6 @@
+ repository='git https://github.com/libexpat/libexpat.git'
+ repository_subdir='expat'
+ bootstrap='./buildconf.sh && make -C doc all'
+-mirrors='http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}'
++mirrors='http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION} https://github.com/libexpat/libexpat/releases/download/R_${CT_EXPAT_VERSION//./_}'
+ archive_formats='.tar.bz2'
+ relevantpattern='*.*|.'


### PR DESCRIPTION
In this branch the Dockerfiles can now be built properly in Linux on x86. JLink was removed from zephyr-sdk-ada-base due to several missing dependencies. Patches were added to download isl and expat from the correct mirrors.